### PR TITLE
v2/guide/instance.md - proposition de traduction

### DIFF
--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -30,7 +30,7 @@ var MyComponent = Vue.extend({
 var myComponentInstance = new MyComponent()
 ```
 
-Bien qu'il soit possible de créer des instances étendues de manière impérative, la plupart du temps il est recommandé de les composer de manière déclarative dans les templates en tant qu'éléments custom. Nous parlerons du [système de composants](components.html) en détail plus loin.
+Bien qu'il soit possible de créer des instances étendues de manière impérative, la plupart du temps il est recommandé de les composer de manière déclarative dans les templates en tant qu'éléments personnalisés. Nous parlerons du [système de composants](components.html) en détail plus loin.
 Pour le moment, vous avez juste besoin de savoir que tous les composants de Vue sont fondamentalement des instances de Vue étendues. 
 
 ## Propriétés et méthodes

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -25,7 +25,7 @@ var MyComponent = Vue.extend({
   // options d'extension
 })
 
-// toutes les instances de `MyComponent` sont créees avec
+// toutes les instances de `MyComponent` sont créées avec
 // les options d'extension prédéfinies
 var myComponentInstance = new MyComponent()
 ```
@@ -83,7 +83,7 @@ Consultez [l'API](../api) pour une liste complète des propriétés et méthodes
 
 ## Les hooks de cycle de vie d'une instance
 
-Chaque instance de vue traverse une série d'étapes d'initialisation au moment de sa création - par exemple, elle doit mettre en place l'observation des données, compiler le template, monter l'instance sur le DOM et mettre à jour le DOM quand les données changent. En cours de route, elle va aussi invoquer des **hooks de cycle de vie**, qui nous donnent l'opportunité d'exécuter une logique personnalisée. Par exemple, le hook `created` est appelé une fois l'instance créee.
+Chaque instance de vue traverse une série d'étapes d'initialisation au moment de sa création - par exemple, elle doit mettre en place l'observation des données, compiler le template, monter l'instance sur le DOM et mettre à jour le DOM quand les données changent. En cours de route, elle va aussi invoquer des **hooks de cycle de vie**, qui nous donnent l'opportunité d'exécuter une logique personnalisée. Par exemple, le hook `created` est appelé une fois l'instance créée.
 
 ``` js
 var vm = new Vue({

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -81,9 +81,9 @@ N'utilisez pas les [fonctions fléchées](https://developer.mozilla.org/fr/docs/
 
 Consultez [l'API](../api) pour une liste complète des propriétés et méthodes d'une instance. 
 
-## Les hooks de cycles de vie d'une instance
+## Les hooks de cycle de vie d'une instance
 
-Chaque instance de vue traverse une série d'étapes d'initialisation au moment de sa création - par exemple, elle doit mettre en place l'observation des données, compiler le template, monter l'instance sur le DOM et mettre à jour le DOM quand les données changent. En cours de route, elle va aussi invoquer des **hooks de cycles de vie**, qui nous donnent l'opportunité d'exécuter une logique personnalisée. Par exemple, le hook `created` est appelé une fois l'instance créee.
+Chaque instance de vue traverse une série d'étapes d'initialisation au moment de sa création - par exemple, elle doit mettre en place l'observation des données, compiler le template, monter l'instance sur le DOM et mettre à jour le DOM quand les données changent. En cours de route, elle va aussi invoquer des **hooks de cycle de vie**, qui nous donnent l'opportunité d'exécuter une logique personnalisée. Par exemple, le hook `created` est appelé une fois l'instance créee.
 
 ``` js
 var vm = new Vue({
@@ -98,9 +98,9 @@ var vm = new Vue({
 // -> "a is: 1"
 ```
 
-Il y aussi d'autres hooks qui seront appelés à différentes étapes du cycle de vie d'une instance, par exemple `mounted`, `updated`et `destroyed`. Tous ces hooks de cycles de vie sont appelés avec leur `this` pointant sur l'instance de la vue qui les invoque. Vous vous êtes peut-être demandé où se trouvait le concept de 'contrôleur' dans le monde de Vue et la réponse est : il n'y pas de contrôleurs. Votre logique personnalisée pour un composant sera répartie entre ces hooks de cycle de vie.
+Il y aussi d'autres hooks qui seront appelés à différentes étapes du cycle de vie d'une instance, par exemple `mounted`, `updated`et `destroyed`. Tous ces hooks de cycle de vie sont appelés avec leur `this` pointant sur l'instance de la vue qui les invoque. Vous vous êtes peut-être demandé où se trouvait le concept de 'contrôleur' dans le monde de Vue et la réponse est : il n'y pas de contrôleurs. Votre logique personnalisée pour un composant sera répartie entre ces hooks de cycle de vie.
 
-## Diagramme de cycles de vie
+## Diagramme de cycle de vie
 
 Ci-dessous se trouve le diagramme d'un cycle de vie d'une instance. Vous n'avez pas besoin de tout comprendre de A à Z à ce stade, mais ce diagramme pourra vous être utile dans le futur.
 

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -14,9 +14,9 @@ var vm = new Vue({
 })
 ```
 
-Bien que n'étant pas strictement associée au patron d'architecture [MVVM pattern](https://en.wikipedia.org/wiki/Model_View_ViewModel), La conception de Vue s'en est en partie inspirée. Par convetion, nous utilisons souvent la variable `vm` (abréviation pour ViewModel) pour faire référence à nos instances de Vue.
+Bien que n'étant pas strictement associée au patron d'architecture [MVVM pattern](https://en.wikipedia.org/wiki/Model_View_ViewModel), la conception de Vue s'en est en partie inspirée. Par convention, nous utilisons souvent la variable `vm` (abréviation pour ViewModel) pour faire référence à nos instances de Vue.
 
-Quand vous créez une instance de Vue, vous devez passer un **objet d'options** qui contient les options pour les data, le template, l'element de montage, les methodes, les fonctions de retour du cycle de vie etc... La liste des options peut être trouvée [dans la documentation de l'API](../api).
+Quand vous créez une instance de Vue, vous devez passer un **objet d'options** qui contient les options pour les données, le template, l'element de montage, les méthodes, les fonctions de retour du cycle de vie etc... La liste des options peut être trouvée [dans la documentation de l'API](../api).
 
 Le constructeur de `Vue` peut être étendu pour créer des **constructeurs de composants** réutilisables avec des options prédéfinies.
 
@@ -25,7 +25,7 @@ var MyComponent = Vue.extend({
   // options d'extension
 })
 
-// toutes les isntances de `MyComponent` sont créees avec
+// toutes les instances de `MyComponent` sont créees avec
 // les options d'extension prédéfinies
 var myComponentInstance = new MyComponent()
 ```
@@ -35,7 +35,7 @@ Pour le moment, vous avez juste besoin de savoir que tous les composants de Vue 
 
 ## Propriétés et méthodes
 
-Chaque instance de vue **reflète ( ou référence  )** toutes les propriétés contenues dans son objet "data"
+Chaque instance de vue **"proxifie"** toutes les propriétés contenues dans son objet "data"
 
 
 ``` js
@@ -46,7 +46,7 @@ var vm = new Vue({
 
 vm.a === data.a // -> true
 
-// affecter la propriété affecte également la donnée originale
+// assigner la propriété affecte également la donnée originale
 vm.a = 2
 data.a // -> 2
 
@@ -55,9 +55,9 @@ data.a = 3
 vm.a // -> 3
 ```
 
-Soulignons que seuls ces propriétés reflétées sont réactives. Si vous attachez une nouvelle propriété à l'instance après sa création, elle ne déclenchera aucune mise à jour de la vue. Nous parlerons plus loin du système de réactivité en détail.
+Soulignons que seuls ces propriétés proxifiées sont réactives. Si vous attachez une nouvelle propriété à l'instance après sa création, elle ne déclenchera aucune mise à jour de la vue. Nous parlerons plus loin du système de réactivité en détail.
 
-En plus des propriétés de data, les instances de Vue exposent de nombreuses méthodes et propriétés utiles. Ces propriétés et méthodes sont préfixées par `$` pour les différencier des propriétés reflétées de data. Par exemple :
+En plus des propriétés de data, les instances de Vue exposent de nombreuses méthodes et propriétés utiles. Ces propriétés et méthodes sont préfixées par `$` pour les différencier des propriétés proxifiées de data. Par exemple :
 
 ``` js
 var data = { a: 1 }
@@ -71,7 +71,7 @@ vm.$el === document.getElementById('example') // -> true
 
 // $watch est une méthode de l'instance
 vm.$watch('a', function (newVal, oldVal) {
-  // cette fonction de retour sera appellée quand `vm.a` changera
+  // cette fonction de retour sera appelée quand `vm.a` changera
 })
 ```
 
@@ -83,7 +83,7 @@ Consultez [l'API](../api) pour une liste complète des propriétés et méthodes
 
 ## Les hooks de cycles de vie d'une instance
 
-Chaque instance de vue traverse une série d'étapes d'initialisations au moment de sa création - par exemple, elle doit mettre en place l'observation des data, compiler le template, monter l'instance sur le DOM et mettre à jour le DOM quand les data changent. En cours de route, elle va aussi invoquer des **hooks de cycles de vie**, qui nous donnent l'opportunité d'exécuter de la logique custom. Par exemple, le hook `created` est appelé après que l'instance sera créee.
+Chaque instance de vue traverse une série d'étapes d'initialisation au moment de sa création - par exemple, elle doit mettre en place l'observation des données, compiler le template, monter l'instance sur le DOM et mettre à jour le DOM quand les données changent. En cours de route, elle va aussi invoquer des **hooks de cycles de vie**, qui nous donnent l'opportunité d'exécuter une logique personnalisée. Par exemple, le hook `created` est appelé une fois l'instance créee.
 
 ``` js
 var vm = new Vue({
@@ -98,7 +98,7 @@ var vm = new Vue({
 // -> "a is: 1"
 ```
 
-Il y aussi d'autres hook qui seront appelés à différentes étapes d'un cycle de vie d'une instance, par exemple `mounted`, `updated`et `destroyed`. Tous ces hooks de cycles de vie sont appelés avec leur `this` pointant sur l'instance de la vue qui les invoquent. Vous vous êtes peut-être demandé où se trouvait le concept de 'controleur' dans le monde de Vue et la réponse est : il n'y pas de controleurs. Votre logique custom pour un composant sera partagée entre ces différents cycles de vie.
+Il y aussi d'autres hooks qui seront appelés à différentes étapes du cycle de vie d'une instance, par exemple `mounted`, `updated`et `destroyed`. Tous ces hooks de cycles de vie sont appelés avec leur `this` pointant sur l'instance de la vue qui les invoque. Vous vous êtes peut-être demandé où se trouvait le concept de 'contrôleur' dans le monde de Vue et la réponse est : il n'y pas de contrôleurs. Votre logique personnalisée pour un composant sera répartie entre ces hooks de cycle de vie.
 
 ## Diagramme de cycles de vie
 

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -35,7 +35,7 @@ Pour le moment, vous avez juste besoin de savoir que tous les composants de Vue 
 
 ## Propriétés et méthodes
 
-Chaque instance de vue **"proxifie"** toutes les propriétés contenues dans son objet "data"
+Chaque instance de vue **"proxifie"** toutes les propriétés contenues dans son objet `data`
 
 
 ``` js
@@ -55,7 +55,7 @@ data.a = 3
 vm.a // -> 3
 ```
 
-Soulignons que seuls ces propriétés proxifiées sont réactives. Si vous attachez une nouvelle propriété à l'instance après sa création, elle ne déclenchera aucune mise à jour de la vue. Nous parlerons plus loin du système de réactivité en détail.
+Soulignons que seuls ces propriétés proxifiées sont **réactives**. Si vous attachez une nouvelle propriété à l'instance après sa création, elle ne déclenchera aucune mise à jour de la vue. Nous parlerons plus loin du système de réactivité en détail.
 
 En plus des propriétés de data, les instances de Vue exposent de nombreuses méthodes et propriétés utiles. Ces propriétés et méthodes sont préfixées par `$` pour les différencier des propriétés proxifiées de data. Par exemple :
 
@@ -98,7 +98,7 @@ var vm = new Vue({
 // -> "a is: 1"
 ```
 
-Il y aussi d'autres hooks qui seront appelés à différentes étapes du cycle de vie d'une instance, par exemple `mounted`, `updated`et `destroyed`. Tous ces hooks de cycle de vie sont appelés avec leur `this` pointant sur l'instance de la vue qui les invoque. Vous vous êtes peut-être demandé où se trouvait le concept de 'contrôleur' dans le monde de Vue et la réponse est : il n'y pas de contrôleurs. Votre logique personnalisée pour un composant sera répartie entre ces hooks de cycle de vie.
+Il y aussi d'autres hooks qui seront appelés à différentes étapes du cycle de vie d'une instance, par exemple `mounted`, `updated`et `destroyed`. Tous ces hooks de cycle de vie sont appelés avec leur `this` pointant sur l'instance de la vue qui les invoque. Vous vous êtes peut-être demandé où se trouvait le concept de "contrôleur" dans le monde de Vue et la réponse est : il n'y pas de contrôleurs. Votre logique personnalisée pour un composant sera répartie entre ces hooks de cycle de vie.
 
 ## Diagramme de cycle de vie
 

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -6,8 +6,6 @@ order: 3
 
 ## Constructeur
 
-<p class="tip">**Cette page est en cours de traduction française. Revenez une autre fois pour lire une traduction achevée ou [participez à la traduction française ici](https://github.com/vuejs-fr/vuejs.org).**</p>
-
 Chaque Vue vm est initialisée en créant une **instance racine de Vue** avec le constructeur de la fonction `Vue`
 
 ``` js

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -1,12 +1,14 @@
 ---
-title: The Vue Instance
+title: L'instance de Vue
 type: guide
 order: 3
 ---
 
-## Constructor
+## Constructeur
 
-<p class="tip">**Cette page est en cours de traduction française. Revenez une autre fois pour lire une traduction achevée ou [participez à la traduction française ici](https://github.com/vuejs-fr/vuejs.org).**</p>Every Vue vm is bootstrapped by creating a **root Vue instance** with the `Vue` constructor function:
+<p class="tip">**Cette page est en cours de traduction française. Revenez une autre fois pour lire une traduction achevée ou [participez à la traduction française ici](https://github.com/vuejs-fr/vuejs.org).**</p>
+
+Chaque Vue vm est initialisée en créant une **instance racine de Vue** avec le constructeur de la fonction `Vue`
 
 ``` js
 var vm = new Vue({
@@ -14,27 +16,29 @@ var vm = new Vue({
 })
 ```
 
-Although not strictly associated with the [MVVM pattern](https://en.wikipedia.org/wiki/Model_View_ViewModel), Vue's design was partly inspired by it. As a convention, we often use the variable `vm` (short for ViewModel) to refer to our Vue instances.
+Bien que n'étant pas strictement associée au patron d'architecture [MVVM pattern](https://en.wikipedia.org/wiki/Model_View_ViewModel), La conception de Vue s'en est en partie inspirée. Par convetion, nous utilisons souvent la variable `vm` (abréviation pour ViewModel) pour faire référence à nos instances de Vue.
 
-When you instantiate a Vue instance, you need to pass in an **options object** which can contain options for data, template, element to mount on, methods, lifecycle callbacks and more. The full list of options can be found in the [API reference](../api).
+Quand vous créez une instance de Vue, vous devez passer un **objet d'options** qui contient les options pour les data, le template, l'element de montage, les methodes, les fonctions de retour du cycle de vie etc... La liste des options peut être trouvée [dans la documentation de l'API](../api).
 
-The `Vue` constructor can be extended to create reusable **component constructors** with pre-defined options:
+Le constructeur de `Vue` peut être étendu pour créer des **constructeurs de composants** réutilisables avec des options prédéfinies.
 
 ``` js
 var MyComponent = Vue.extend({
-  // extension options
+  // options d'extension
 })
 
-// all instances of `MyComponent` are created with
-// the pre-defined extension options
+// toutes les isntances de `MyComponent` sont créees avec
+// les options d'extension prédéfinies
 var myComponentInstance = new MyComponent()
 ```
 
-Although it is possible to create extended instances imperatively, most of the time it is recommended to compose them declaratively in templates as custom elements. We will talk about [the component system](components.html) in detail later. For now, you just need to know that all Vue components are essentially extended Vue instances.
+Bien qu'il soit possible de créer des instances étendues de manière impérative, la plupart du temps il est recommandé de les composer de manière déclarative dans les templates en tant qu'éléments custom. Nous parlerons du [système de composants](components.html) en détail plus loin.
+Pour le moment, vous avez juste besoin de savoir que tous les composants de Vue sont fondamentalement des instances de Vue étendues. 
 
-## Properties and Methods
+## Propriétés et méthodes
 
-Each Vue instance **proxies** all the properties found in its `data` object:
+Chaque instance de vue **reflète ( ou référence  )** toutes les propriétés contenues dans son objet "data"
+
 
 ``` js
 var data = { a: 1 }
@@ -44,18 +48,18 @@ var vm = new Vue({
 
 vm.a === data.a // -> true
 
-// setting the property also affects original data
+// affecter la propriété affecte également la donnée originale
 vm.a = 2
 data.a // -> 2
 
-// ... and vice-versa
+// ... et vice-versa
 data.a = 3
 vm.a // -> 3
 ```
 
-It should be noted that only these proxied properties are **reactive**. If you attach a new property to the instance after it has been created, it will not trigger any view updates. We will discuss the reactivity system in detail later.
+Soulignons que seuls ces propriétés reflétées sont réactives. Si vous attachez une nouvelle propriété à l'instance après sa création, elle ne déclenchera aucune mise à jour de la vue. Nous parlerons plus loin du système de réactivité en détail.
 
-In addition to data properties, Vue instances expose a number of useful instance properties and methods. These properties and methods are prefixed with `$` to differentiate them from proxied data properties. For example:
+En plus des propriétés de data, les instances de Vue exposent de nombreuses méthodes et propriétés utiles. Ces propriétés et méthodes sont préfixées par `$` pour les différencier des propriétés reflétées de data. Par exemple :
 
 ``` js
 var data = { a: 1 }
@@ -67,19 +71,21 @@ var vm = new Vue({
 vm.$data === data // -> true
 vm.$el === document.getElementById('example') // -> true
 
-// $watch is an instance method
+// $watch est une méthode de l'instance
 vm.$watch('a', function (newVal, oldVal) {
-  // this callback will be called when `vm.a` changes
+  // cette fonction de retour sera appellée quand `vm.a` changera
 })
 ```
 
-<p class="tip">Don't use [arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) on an instance property or callback (e.g. `vm.$watch('a', newVal => this.myMethod())`). As arrow functions are bound to the parent context, `this` will not be the Vue instance as you'd expect and `this.myMethod` will be undefined.</p>
+<p class="tip">
+N'utilisez pas les [fonctions fléchées](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Fonctions/Fonctions_fl%C3%A9ch%C3%A9es) sur une propriété ou fonction de retour d'une instance  (par exemple `vm.$watch('a', newVal => this.myMethod())`). Comme les fonctions fléchées sont liées au contexte parent, `this` ne sera pas l'instance de Vue comme vous pourriez vous y attendre et `this.myMethod` sera indéfini.
+</p>
 
-Consult the [API reference](../api) for the full list of instance properties and methods.
+Consultez [l'API](../api) pour une liste complète des propriétés et méthodes d'une instance. 
 
-## Instance Lifecycle Hooks
+## Les hooks de cycles de vie d'une instance
 
-Each Vue instance goes through a series of initialization steps when it is created - for example, it needs to set up data observation, compile the template, mount the instance to the DOM, and update the DOM when data changes. Along the way, it will also invoke some **lifecycle hooks**, which give us the opportunity to execute custom logic. For example, the `created` hook is called after the instance is created:
+Chaque instance de vue traverse une série d'étapes d'initialisations au moment de sa création - par exemple, elle doit mettre en place l'observation des data, compiler le template, monter l'instance sur le DOM et mettre à jour le DOM quand les data changent. En cours de route, elle va aussi invoquer des **hooks de cycles de vie**, qui nous donnent l'opportunité d'exécuter de la logique custom. Par exemple, le hook `created` est appelé après que l'instance sera créee.
 
 ``` js
 var vm = new Vue({
@@ -87,17 +93,18 @@ var vm = new Vue({
     a: 1
   },
   created: function () {
-    // `this` points to the vm instance
+    // `this` référence l'instance de vm
     console.log('a is: ' + this.a)
   }
 })
 // -> "a is: 1"
 ```
 
-There are also other hooks which will be called at different stages of the instance's lifecycle, for example `mounted`, `updated`, and `destroyed`. All lifecycle hooks are called with their `this` context pointing to the Vue instance invoking it. You may have been wondering where the concept of "controllers" lives in the Vue world and the answer is: there are no controllers. Your custom logic for a component would be split among these lifecycle hooks.
+Il y aussi d'autres hook qui seront appelés à différentes étapes d'un cycle de vie d'une instance, par exemple `mounted`, `updated`et `destroyed`. Tous ces hooks de cycles de vie sont appelés avec leur `this` pointant sur l'instance de la vue qui les invoquent. Vous vous êtes peut-être demandé où se trouvait le concept de 'controleur' dans le monde de Vue et la réponse est : il n'y pas de controleurs. Votre logique custom pour un composant sera partagée entre ces différents cycles de vie.
 
-## Lifecycle Diagram
+## Diagramme de cycles de vie
 
-Below is a diagram for the instance lifecycle. You don't need to fully understand everything going on right now, but this diagram will be helpful in the future.
+Ci-dessous se trouve le diagramme d'un cycle de vie d'une instance. Vous n'avez pas besoin de tout comprendre de A à Z à ce stade, mais ce diagramme pourra vous être utile dans le futur.
+
 
 ![Lifecycle](/images/lifecycle.png)

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -91,7 +91,7 @@ var vm = new Vue({
     a: 1
   },
   created: function () {
-    // `this` référence l'instance de vm
+    // `this` référence à l'instance de vm
     console.log('a is: ' + this.a)
   }
 })


### PR DESCRIPTION
Voici une proposition de traduction pour la page sur les instances de Vue.
J'ai galérer sur la traduction du mot **proxies** et **proxied** dans les phrases suivantes : 

> Each Vue instance proxies all the properties found in its data object

>It should be noted that only these proxied properties are reactive

j'ai mis "référencer" et "refléter" en attendant de meilleures suggestions.
J'hésite aussi sur la traduction de "custom logic" qui se retrouve souvent dans la doc (j'ai mis logique custom en attendant)