### PR TITLE
Traduction forms.md

### DIFF
--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -339,7 +339,7 @@ vm.selected.number // -> 123
 
 ### `.lazy`
 
-Par défaut, `v-model` synchronise l'input avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place : 
+Par défaut, `v-model` synchronise le champ avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place : 
 
 ``` html
 <!-- synchronisé après le "change" au lieu du "input" -->

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -1,18 +1,19 @@
 ---
-title: Form Input Bindings
+title: Liaisons des champs de formulaire
 type: guide
 order: 10
 ---
 
-## Basic Usage
+## Usage basique
 
-<p class="tip">**Cette page est en cours de traduction française. Revenez une autre fois pour lire une traduction achevée ou [participez à la traduction française ici](https://github.com/vuejs-fr/vuejs.org).**</p>You can use the `v-model` directive to create two-way data bindings on form input and textarea elements. It automatically picks the correct way to update the element based on the input type. Although a bit magical, `v-model` is essentially syntax sugar for updating data on user input events, plus special care for some edge cases.
+Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire et les ((textarea|zones de textes multilignes)). Elle choisira automatiquement la bonne manière de mettre à jour l'élément selon le type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ((plus quelques traitements spéciaux pour les cas particuliers)).
 
-<p class="tip">`v-model` doesn't care about the initial value provided to an input or a textarea. It will always treat the Vue instance data as the source of truth.</p>
+<p class="tip">`v-model` ne prend pas en compte la valeur initial fourni par un champ ou une zone de texte. Il traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 
 <p class="tip" id="vmodel-ime-tip">For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) (Chinese, Japanese, Korean etc.), you'll notice that `v-model` doesn't get updated during IME composition. If you want to cater for these updates as well, use `input` event instead.</p>
+<p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mis à jour durant ((l'exécution de la méthode de saisie.))</p>
 
-### Text
+### Texte
 
 ``` html
 <input v-model="message" placeholder="edit me">
@@ -34,7 +35,7 @@ new Vue({
 </script>
 {% endraw %}
 
-### Multiline text
+### Text multilignes
 
 ``` html
 <span>Multiline message is:</span>

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -6,11 +6,11 @@ order: 10
 
 ## Usage basique
 
-Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire et textarea. Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, plus quelques traitements spéciaux pour certains cas particuliers.
+Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire. Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ainsi que quelques traitements spéciaux pour certains cas particuliers.
 
-<p class="tip">`v-model` ne prend pas en compte la valeur initiale fournie pour un champ ou un textarea. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
+<p class="tip">`v-model` ne prend pas en compte la valeur initiale (attribut "value") fournie pour champ. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 
-<p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mis à jour durant l'exécution de la méthode de saisie.</p>
+<p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mise à jour durant l'exécution de la méthode de saisie.</p>
 
 ### Texte
 
@@ -226,7 +226,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Options dynamiques rendues avec `v-for`:
+Options dynamiques générées avec `v-for`:
 
 ``` html
 <select v-model="selected">
@@ -307,7 +307,7 @@ Mais parfois nous pouvons souhaiter lier la valeur à une propriété dynamique 
 ``` js
 // quand cochée :
 vm.toggle === vm.a
-// when unchecked:
+// quand décochée :
 vm.toggle === vm.b
 ```
 
@@ -341,7 +341,7 @@ vm.selected.number // -> 123
 
 ### `.lazy`
 
-Par défaut, `v-model` synchronise l'input avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place: 
+Par défaut, `v-model` synchronise le champ avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place: 
 
 ``` html
 <!-- synchronisé après le "change" au lieu du "input" -->
@@ -350,7 +350,7 @@ Par défaut, `v-model` synchronise l'input avec les données après chaque évè
 
 ### `.number`
 
-Si vous voulez que l'entrée utilisateur soit automatiquement typée en tant que nombre, vous pouvez ajouter le modificateur `number` à vos input gérés par `v-model`
+Si vous voulez que l'entrée utilisateur soit automatiquement typée en tant que nombre, vous pouvez ajouter le modificateur `number` à vos champs gérés par `v-model`
 
 ``` html
 <input v-model.number="age" type="number">
@@ -360,7 +360,6 @@ C'est souvent utile, parce que même avec `type="number"`, la valeur des éléme
 
 ### `.trim`
 
-If you want user input to be trimmed automatically, you can add the `trim` modifier to your `v-model` managed inputs:
 c'est vous voulez que les entrées utilisateurs soit "trimmed" automatiquement, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model`
 
 ```html
@@ -371,7 +370,7 @@ c'est vous voulez que les entrées utilisateurs soit "trimmed" automatiquement, 
 
 > Si vous n'est pas encore familier avec les composants de Vue, sautez ce passage pour le moment
 
-Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des inputs avec un comportement complètement customisé. Ces inputs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez [inputs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
+Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des champs avec un comportement complètement personnalisé. Ces champs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez les [champs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
 
 
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -10,7 +10,6 @@ Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée b
 
 <p class="tip">`v-model` ne prend pas en compte la valeur initial fourni par un champ ou une zone de texte. Il traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 
-<p class="tip" id="vmodel-ime-tip">For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) (Chinese, Japanese, Korean etc.), you'll notice that `v-model` doesn't get updated during IME composition. If you want to cater for these updates as well, use `input` event instead.</p>
 <p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mis à jour durant ((l'exécution de la méthode de saisie.))</p>
 
 ### Texte
@@ -35,7 +34,7 @@ new Vue({
 </script>
 {% endraw %}
 
-### Text multilignes
+### Texte multiligne
 
 ``` html
 <span>Multiline message is:</span>
@@ -64,11 +63,13 @@ new Vue({
 
 {% raw %}
 <p class="tip">Interpolation on textareas (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) won't work. Use <code>v-model</code> instead.</p>
+<p class="tip">Les interpolations sur les textareas (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionneront pas. Utilisez <code>v-model</code> à la place.</p>
 {% endraw %}
 
 ### Checkbox
 
-Single checkbox, boolean value:
+((Checkbox seule, valeur booléenne:))
+
 
 ``` html
 <input type="checkbox" id="checkbox" v-model="checked">
@@ -89,7 +90,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Multiple checkboxes, bound to the same Array:
+Checkboxes multiple, liées au même Array:
 
 ``` html
 <input type="checkbox" id="jack" value="Jack" v-model="checkedNames">
@@ -166,7 +167,7 @@ new Vue({
 
 ### Select
 
-Single select:
+Select à choix unique:
 
 ``` html
 <select v-model="selected">
@@ -195,7 +196,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Multiple select (bound to Array):
+Select à choix multiple (lié à Array):
 
 ``` html
 <select v-model="selected" multiple>
@@ -226,7 +227,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Dynamic options rendered with `v-for`:
+Options dynamiques rendues avec `v-for`:
 
 ``` html
 <select v-model="selected">
@@ -274,23 +275,25 @@ new Vue({
 {% endraw %}
 
 ## Value Bindings
+## Liaisons de value
 
 For radio, checkbox and select options, the `v-model` binding values are usually static strings (or booleans for checkbox):
+Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` sont habituellement des chaînes de caractères statiques (ou des booléens pour checkbox):
 
 ``` html
-<!-- `picked` is a string "a" when checked -->
+<!-- `picked` est une chaîne de caractères "a" quand le bouton radio est sélectionné -->
 <input type="radio" v-model="picked" value="a">
 
-<!-- `toggle` is either true or false -->
+<!-- `toggle` est soit true soit false -->
 <input type="checkbox" v-model="toggle">
 
-<!-- `selected` is a string "abc" when selected -->
+<!-- `selected` est une chaîne de caractères "abc" quand l'option est sélectionnée -->
 <select v-model="selected">
   <option value="abc">ABC</option>
 </select>
 ```
 
-But sometimes we may want to bind the value to a dynamic property on the Vue instance. We can use `v-bind` to achieve that. In addition, using `v-bind` allows us to bind the input value to non-string values.
+Mais parfois nous pouvons souhaiter lier la valeur à une propriété dynamique de l'instance de Vue. Nous pouvons réaliser cela en utilisant `v-bind`. De plus, utiliser `v-bind` nous permet de lier la valeur de l'input à des valeurs qui ne sont pas des chaînes de caractères.
 
 ### Checkbox
 
@@ -321,29 +324,30 @@ vm.toggle === vm.b
 vm.pick === vm.a
 ```
 
-### Select Options
+### Options des select
 
 ``` html
 <select v-model="selected">
-  <!-- inline object literal -->
+  <!-- objet littéral en ligne -->
   <option v-bind:value="{ number: 123 }">123</option>
 </select>
 ```
 
 ``` js
-// when selected:
+// quand sélectionné :
 typeof vm.selected // -> 'object'
 vm.selected.number // -> 123
 ```
 
-## Modifiers
+## Modificateur
 
 ### `.lazy`
 
-By default, `v-model` syncs the input with the data after each `input` event (with the exception of IME composition as [stated above](#vmodel-ime-tip)). You can add the `lazy` modifier to instead sync after `change` events:
+Par défaut, `v-model` synchronise l'input avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place: 
 
 ``` html
 <!-- synced after "change" instead of "input" -->
+<!-- synchronisé après le "change" au lieu du "input" -->
 <input v-model.lazy="msg" >
 ```
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -276,7 +276,6 @@ new Vue({
 
 Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` sont habituellement des chaînes de caractères statiques (ou des booléens pour une checkbox) :
 
-
 ``` html
 <!-- `picked` sera une chaîne de caractères "a" quand le bouton radio sera sélectionné -->
 <input type="radio" v-model="picked" value="a">

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -320,7 +320,7 @@ vm.toggle === vm.b
 vm.pick === vm.a
 ```
 
-### Options des select
+### Options de select
 
 ``` html
 <select v-model="selected">

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -62,7 +62,7 @@ new Vue({
 
 
 {% raw %}
-<p class="tip">L'interpolation sur les textarea (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionnera pas. Utilisez <code>v-model</code> à la place.</p>
+<p class="tip">L'interpolation sur les textareas (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionnera pas. Utilisez <code>v-model</code> à la place.</p>
 {% endraw %}
 
 ### Checkbox

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -6,7 +6,7 @@ order: 10
 
 ## Usage basique
 
-Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire (input, select ou textarea). Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ainsi que quelques traitements spéciaux pour certains cas particuliers.
+Vous pouvez utiliser la directive `v-model` pour créer une liaison de données bidirectionnelle sur les champs de formulaire (input, select ou textarea). Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement du sucre syntaxique pour mettre à jour les données lors des évènements de saisie utilisateur sur les champs, ainsi que quelques traitements spéciaux pour certains cas particuliers.
 
 <p class="tip">`v-model` ne prend pas en compte la valeur initiale (attribut "value") fournie pour un champ. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 
@@ -15,13 +15,13 @@ Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée b
 ### Texte
 
 ``` html
-<input v-model="message" placeholder="modifiez moi">
+<input v-model="message" placeholder="modifiez-moi">
 <p>Le message est : {{ message }}</p>
 ```
 
 {% raw %}
 <div id="example-1" class="demo">
-  <input v-model="message" placeholder="modifiez moi">
+  <input v-model="message" placeholder="modifiez-moi">
   <p>Le message est : {{ message }}</p>
 </div>
 <script>
@@ -62,7 +62,7 @@ new Vue({
 
 
 {% raw %}
-<p class="tip">L'interpolation sur les textareas (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionnera pas. Utilisez <code>v-model</code> à la place.</p>
+<p class="tip">L'interpolation sur les zones de texte (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionnera pas. Utilisez <code>v-model</code> à la place.</p>
 {% endraw %}
 
 ### Checkbox
@@ -274,7 +274,7 @@ new Vue({
 
 ## Liaisons des attributs value
 
-Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` sont habituellement des chaînes de caractères statiques (ou des booléens pour une checkbox) :
+Pour les boutons radio, les cases à cocher et les listes d'options, les valeurs de liaison de `v-model` sont habituellement des chaînes de caractères statiques (ou des booléens pour une case à cocher) :
 
 ``` html
 <!-- `picked` sera une chaîne de caractères "a" quand le bouton radio sera sélectionné -->
@@ -339,7 +339,7 @@ vm.selected.number // -> 123
 
 ### `.lazy`
 
-Par défaut, `v-model` synchronise le champ avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place : 
+Par défaut, `v-model` synchronise le champ avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [mentionné plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place : 
 
 ``` html
 <!-- synchronisé après le "change" au lieu du "input" -->
@@ -348,7 +348,7 @@ Par défaut, `v-model` synchronise le champ avec les données après chaque év�
 
 ### `.number`
 
-Si vous voulez que la saisie utilisateur soit automatiquement typée en tant que nombre, vous pouvez ajouter le modificateur `number` à vos input gérés par `v-model` :
+Si vous voulez que la saisie utilisateur soit automatiquement convertie en tant que nombre, vous pouvez ajouter le modificateur `number` à vos champs gérés par `v-model` :
 
 ``` html
 <input v-model.number="age" type="number">
@@ -358,7 +358,7 @@ C'est souvent utile, parce que même avec `type="number"`, la valeur des éléme
 
 ### `.trim`
 
-Si vous voulez que les saisies utilisateurs soit automatiquement nettoyées des espaces superflus, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model` :
+Si vous voulez que les espaces superflus des saisies utilisateur soient automatiquement retirés, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model` :
 
 ```html
 <input v-model.trim="msg">
@@ -368,7 +368,7 @@ Si vous voulez que les saisies utilisateurs soit automatiquement nettoyées des 
 
 > Si vous n'êtes pas encore familier avec les composants de Vue, passez cette section pour le moment.
 
-Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des champs avec un comportement complètement personnalisé. Ces champs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez [champs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
+Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des champs avec un comportement complètement personnalisé. Ces champs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez la section ["champs personnalisés"](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
 
 
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -89,7 +89,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Checkboxes multiples, liées au même tableau (Array):
+Checkboxes multiples, liées au même tableau (Array) :
 
 ``` html
 <input type="checkbox" id="jack" value="Jack" v-model="checkedNames">
@@ -360,7 +360,7 @@ C'est souvent utile, parce que même avec `type="number"`, la valeur des éléme
 
 ### `.trim`
 
-c'est vous voulez que les saisies utilisateurs soit automatiquement nettoyées des espaces superflus, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model`
+c'est vous voulez que les saisies utilisateurs soit automatiquement nettoyées des espaces superflus, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model` :
 
 ```html
 <input v-model.trim="msg">

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -1,5 +1,5 @@
 ---
-title: Liaisons des champs de formulaire
+title: Liaisons sur les champs de formulaire
 type: guide
 order: 10
 ---
@@ -8,20 +8,20 @@ order: 10
 
 Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire. Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ainsi que quelques traitements spéciaux pour certains cas particuliers.
 
-<p class="tip">`v-model` ne prend pas en compte la valeur initiale (attribut "value") fournie pour champ. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
+<p class="tip">`v-model` ne prend pas en compte la valeur initiale (attribut "value") fournie pour un champ. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 
-<p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mise à jour durant l'exécution de la méthode de saisie.</p>
+<p class="tip" id="vmodel-ime-tip">Pour les langues qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc...), vous remarquerez que `v-model` ne sera pas mise à jour durant l'exécution de la méthode de saisie.</p>
 
 ### Texte
 
 ``` html
-<input v-model="message" placeholder="éditez moi">
+<input v-model="message" placeholder="modifiez moi">
 <p>Le message est : {{ message }}</p>
 ```
 
 {% raw %}
 <div id="example-1" class="demo">
-  <input v-model="message" placeholder="éditez moi">
+  <input v-model="message" placeholder="modifiez moi">
   <p>Le message est : {{ message }}</p>
 </div>
 <script>
@@ -62,7 +62,7 @@ new Vue({
 
 
 {% raw %}
-<p class="tip">Les interpolations sur les textarea (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionneront pas. Utilisez <code>v-model</code> à la place.</p>
+<p class="tip">L'interpolation sur les textarea (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionnera pas. Utilisez <code>v-model</code> à la place.</p>
 {% endraw %}
 
 ### Checkbox
@@ -89,7 +89,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Checkboxes multiples, liées au même Array:
+Checkboxes multiples, liées au même tableau (Array):
 
 ``` html
 <input type="checkbox" id="jack" value="Jack" v-model="checkedNames">
@@ -99,7 +99,7 @@ Checkboxes multiples, liées au même Array:
 <input type="checkbox" id="mike" value="Mike" v-model="checkedNames">
 <label for="mike">Mike</label>
 <br>
-<span>Nom cochés : {{ checkedNames }}</span>
+<span>Noms cochés : {{ checkedNames }}</span>
 ```
 
 ``` js
@@ -136,21 +136,21 @@ new Vue({
 
 
 ``` html
-<input type="radio" id="one" value="One" v-model="picked">
-<label for="one">One</label>
+<input type="radio" id="one" value="Un" v-model="picked">
+<label for="one">Un</label>
 <br>
-<input type="radio" id="two" value="Two" v-model="picked">
-<label for="two">Two</label>
+<input type="radio" id="two" value="Deux" v-model="picked">
+<label for="two">Deux</label>
 <br>
 <span>Choisi : {{ picked }}</span>
 ```
 {% raw %}
 <div id="example-4" class="demo">
-  <input type="radio" id="one" value="One" v-model="picked">
-  <label for="one">One</label>
+  <input type="radio" id="one" value="Un" v-model="picked">
+  <label for="one">Un</label>
   <br>
-  <input type="radio" id="two" value="Two" v-model="picked">
-  <label for="two">Two</label>
+  <input type="radio" id="two" value="Deux" v-model="picked">
+  <label for="two">Deux</label>
   <br>
   <span>Choisi : {{ picked }}</span>
 </div>
@@ -166,7 +166,7 @@ new Vue({
 
 ### Select
 
-Select à choix unique:
+Select à choix unique :
 
 ``` html
 <select v-model="selected">
@@ -195,7 +195,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Select à choix multiples (lié à un Array):
+Select à choix multiples (lié à un tableau) :
 
 ``` html
 <select v-model="selected" multiple>
@@ -204,7 +204,7 @@ Select à choix multiples (lié à un Array):
   <option>C</option>
 </select>
 <br>
-<span>Sélectionnés : {{ selected }}</span>
+<span>Sélectionné(s) : {{ selected }}</span>
 ```
 {% raw %}
 <div id="example-6" class="demo">
@@ -214,7 +214,7 @@ Select à choix multiples (lié à un Array):
     <option>C</option>
   </select>
   <br>
-  <span>Sélectionnés : {{ selected }}</span>
+  <span>Sélectionné(s) : {{ selected }}</span>
 </div>
 <script>
 new Vue({
@@ -226,7 +226,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Options dynamiques générées avec `v-for`:
+Options dynamiques générées avec `v-for` :
 
 ``` html
 <select v-model="selected">
@@ -242,9 +242,9 @@ new Vue({
   data: {
     selected: 'A',
     options: [
-      { text: 'One', value: 'A' },
-      { text: 'Two', value: 'B' },
-      { text: 'Three', value: 'C' }
+      { text: 'Un', value: 'A' },
+      { text: 'Deux', value: 'B' },
+      { text: 'Trois', value: 'C' }
     ]
   }
 })
@@ -264,9 +264,9 @@ new Vue({
   data: {
     selected: 'A',
     options: [
-      { text: 'One', value: 'A' },
-      { text: 'Two', value: 'B' },
-      { text: 'Three', value: 'C' }
+      { text: 'Un', value: 'A' },
+      { text: 'Deux', value: 'B' },
+      { text: 'Trois', value: 'C' }
     ]
   }
 })
@@ -275,7 +275,7 @@ new Vue({
 
 ## Liaisons des attributs value
 
-Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` des attributs value sont habituellement des chaînes de caractères statiques (ou des booléens pour une checkbox):
+Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` sont habituellement des chaînes de caractères statiques (ou des booléens pour une checkbox) :
 
 
 ``` html
@@ -305,9 +305,9 @@ Mais parfois nous pouvons souhaiter lier la valeur à une propriété dynamique 
 ```
 
 ``` js
-// quand cochée :
+// lorsque c'est coché :
 vm.toggle === vm.a
-// quand décochée :
+// lorsque que c'est décoché :
 vm.toggle === vm.b
 ```
 
@@ -318,7 +318,7 @@ vm.toggle === vm.b
 ```
 
 ``` js
-// quand choisi :
+// Lorsque c'est choisi :
 vm.pick === vm.a
 ```
 
@@ -332,16 +332,16 @@ vm.pick === vm.a
 ```
 
 ``` js
-// quand sélectionné :
+// Lorsque c'est sélectionné :
 typeof vm.selected // -> 'object'
 vm.selected.number // -> 123
 ```
 
-## Modificateur
+## Modificateurs
 
 ### `.lazy`
 
-Par défaut, `v-model` synchronise le champ avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place: 
+Par défaut, `v-model` synchronise l'input avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place : 
 
 ``` html
 <!-- synchronisé après le "change" au lieu du "input" -->
@@ -350,7 +350,7 @@ Par défaut, `v-model` synchronise le champ avec les données après chaque év�
 
 ### `.number`
 
-Si vous voulez que l'entrée utilisateur soit automatiquement typée en tant que nombre, vous pouvez ajouter le modificateur `number` à vos champs gérés par `v-model`
+Si vous voulez que la saisie utilisateur soit automatiquement typée en tant que nombre, vous pouvez ajouter le modificateur `number` à vos input gérés par `v-model` :
 
 ``` html
 <input v-model.number="age" type="number">
@@ -360,7 +360,7 @@ C'est souvent utile, parce que même avec `type="number"`, la valeur des éléme
 
 ### `.trim`
 
-c'est vous voulez que les entrées utilisateurs soit "trimmed" automatiquement, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model`
+c'est vous voulez que les saisies utilisateurs soit automatiquement nettoyées des espaces superflus, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model`
 
 ```html
 <input v-model.trim="msg">
@@ -368,9 +368,9 @@ c'est vous voulez que les entrées utilisateurs soit "trimmed" automatiquement, 
 
 ## `v-model` avec les composants
 
-> Si vous n'est pas encore familier avec les composants de Vue, sautez ce passage pour le moment
+> Si vous n'êtes pas encore familier avec les composants de Vue, passez cette section pour le moment.
 
-Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des champs avec un comportement complètement personnalisé. Ces champs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez les [champs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
+Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des inputs avec un comportement complètement customisé. Ces inputs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez [inputs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
 
 
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -6,7 +6,7 @@ order: 10
 
 ## Usage basique
 
-Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire. Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ainsi que quelques traitements spéciaux pour certains cas particuliers.
+Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire (input, select ou textarea). Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ainsi que quelques traitements spéciaux pour certains cas particuliers.
 
 <p class="tip">`v-model` ne prend pas en compte la valeur initiale (attribut "value") fournie pour un champ. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -69,7 +69,6 @@ new Vue({
 
 Checkbox seule, valeur booléenne :
 
-
 ``` html
 <input type="checkbox" id="checkbox" v-model="checked">
 <label for="checkbox">{{ checked }}</label>

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -6,23 +6,23 @@ order: 10
 
 ## Usage basique
 
-Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les ((champs de formulaire)). Elle choisira automatiquement la bonne manière de mettre à jour l'élément selon le type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ((plus quelques traitements spéciaux pour les cas particuliers)).
+Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire et textarea. Elle choisira automatiquement la bonne manière de mettre à jour l'élément en fonction du type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, plus quelques traitements spéciaux pour certains cas particuliers.
 
-<p class="tip">`v-model` ne prend pas en compte la valeur initiale fournie par un champ. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
+<p class="tip">`v-model` ne prend pas en compte la valeur initiale fournie pour un champ ou un textarea. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 
-<p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mis à jour durant ((l'exécution de la méthode de saisie.))</p>
+<p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mis à jour durant l'exécution de la méthode de saisie.</p>
 
 ### Texte
 
 ``` html
-<input v-model="message" placeholder="edit me">
-<p>Message is: {{ message }}</p>
+<input v-model="message" placeholder="éditez moi">
+<p>Le message est : {{ message }}</p>
 ```
 
 {% raw %}
 <div id="example-1" class="demo">
-  <input v-model="message" placeholder="edit me">
-  <p>Message is: {{ message }}</p>
+  <input v-model="message" placeholder="éditez moi">
+  <p>Le message est : {{ message }}</p>
 </div>
 <script>
 new Vue({
@@ -37,18 +37,18 @@ new Vue({
 ### Texte multiligne
 
 ``` html
-<span>Multiline message is:</span>
+<span>Le message multiligne est :</span>
 <p style="white-space: pre">{{ message }}</p>
 <br>
-<textarea v-model="message" placeholder="add multiple lines"></textarea>
+<textarea v-model="message" placeholder="ajoutez plusieurs lignes"></textarea>
 ```
 
 {% raw %}
 <div id="example-textarea" class="demo">
-  <span>Multiline message is:</span>
+  <span>Le message multiligne est :</span>
   <p style="white-space: pre">{{ message }}</p>
   <br>
-  <textarea v-model="message" placeholder="add multiple lines"></textarea>
+  <textarea v-model="message" placeholder="ajoutez plusieurs lignes"></textarea>
 </div>
 <script>
 new Vue({
@@ -67,7 +67,7 @@ new Vue({
 
 ### Checkbox
 
-((Checkbox seule, valeur booléenne:))
+Checkbox seule, valeur booléenne :
 
 
 ``` html
@@ -89,7 +89,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Checkboxes multiple, liées au même Array:
+Checkboxes multiples, liées au même Array:
 
 ``` html
 <input type="checkbox" id="jack" value="Jack" v-model="checkedNames">
@@ -99,7 +99,7 @@ Checkboxes multiple, liées au même Array:
 <input type="checkbox" id="mike" value="Mike" v-model="checkedNames">
 <label for="mike">Mike</label>
 <br>
-<span>Checked names: {{ checkedNames }}</span>
+<span>Nom cochés : {{ checkedNames }}</span>
 ```
 
 ``` js
@@ -120,7 +120,7 @@ new Vue({
   <input type="checkbox" id="mike" value="Mike" v-model="checkedNames">
   <label for="mike">Mike</label>
   <br>
-  <span>Checked names: {{ checkedNames }}</span>
+  <span>Noms cochés : {{ checkedNames }}</span>
 </div>
 <script>
 new Vue({
@@ -142,7 +142,7 @@ new Vue({
 <input type="radio" id="two" value="Two" v-model="picked">
 <label for="two">Two</label>
 <br>
-<span>Picked: {{ picked }}</span>
+<span>Choisi : {{ picked }}</span>
 ```
 {% raw %}
 <div id="example-4" class="demo">
@@ -152,7 +152,7 @@ new Vue({
   <input type="radio" id="two" value="Two" v-model="picked">
   <label for="two">Two</label>
   <br>
-  <span>Picked: {{ picked }}</span>
+  <span>Choisi : {{ picked }}</span>
 </div>
 <script>
 new Vue({
@@ -174,7 +174,7 @@ Select à choix unique:
   <option>B</option>
   <option>C</option>
 </select>
-<span>Selected: {{ selected }}</span>
+<span>Sélectionné : {{ selected }}</span>
 ```
 {% raw %}
 <div id="example-5" class="demo">
@@ -183,7 +183,7 @@ Select à choix unique:
     <option>B</option>
     <option>C</option>
   </select>
-  <span>Selected: {{ selected }}</span>
+  <span>Sélectionné : {{ selected }}</span>
 </div>
 <script>
 new Vue({
@@ -195,7 +195,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Select à choix multiples (lié à Array):
+Select à choix multiples (lié à un Array):
 
 ``` html
 <select v-model="selected" multiple>
@@ -204,7 +204,7 @@ Select à choix multiples (lié à Array):
   <option>C</option>
 </select>
 <br>
-<span>Selected: {{ selected }}</span>
+<span>Sélectionnés : {{ selected }}</span>
 ```
 {% raw %}
 <div id="example-6" class="demo">
@@ -214,7 +214,7 @@ Select à choix multiples (lié à Array):
     <option>C</option>
   </select>
   <br>
-  <span>Selected: {{ selected }}</span>
+  <span>Sélectionnés : {{ selected }}</span>
 </div>
 <script>
 new Vue({
@@ -234,7 +234,7 @@ Options dynamiques rendues avec `v-for`:
     {{ option.text }}
   </option>
 </select>
-<span>Selected: {{ selected }}</span>
+<span>Sélectionné : {{ selected }}</span>
 ```
 ``` js
 new Vue({
@@ -256,7 +256,7 @@ new Vue({
       {{ option.text }}
     </option>
   </select>
-  <span>Selected: {{ selected }}</span>
+  <span>Sélectionné : {{ selected }}</span>
 </div>
 <script>
 new Vue({
@@ -273,9 +273,9 @@ new Vue({
 </script>
 {% endraw %}
 
-## Liaisons de valeurs
+## Liaisons des attributs value
 
-Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` sont habituellement des chaînes de caractères statiques (ou des booléens pour checkbox):
+Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` des attributs value sont habituellement des chaînes de caractères statiques (ou des booléens pour une checkbox):
 
 
 ``` html
@@ -305,7 +305,7 @@ Mais parfois nous pouvons souhaiter lier la valeur à une propriété dynamique 
 ```
 
 ``` js
-// when checked:
+// quand cochée :
 vm.toggle === vm.a
 // when unchecked:
 vm.toggle === vm.b
@@ -344,7 +344,6 @@ vm.selected.number // -> 123
 Par défaut, `v-model` synchronise l'input avec les données après chaque évènement `input` (à l'exception de l'exécution d'une méthode de saisie comme [dit plus haut](#vmodel-ime-tip)). Vous pouvez ajouter le modificateur `lazy` pour synchroniser après les évènements `change` à la place: 
 
 ``` html
-<!-- synced after "change" instead of "input" -->
 <!-- synchronisé après le "change" au lieu du "input" -->
 <input v-model.lazy="msg" >
 ```

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -368,7 +368,7 @@ Si vous voulez que les saisies utilisateurs soit automatiquement nettoyées des 
 
 > Si vous n'êtes pas encore familier avec les composants de Vue, passez cette section pour le moment.
 
-Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des inputs avec un comportement complètement customisé. Ces inputs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez [inputs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
+Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des champs avec un comportement complètement personnalisé. Ces champs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez [champs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
 
 
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -350,27 +350,28 @@ Par défaut, `v-model` synchronise l'input avec les données après chaque évè
 
 ### `.number`
 
-If you want user input to be automatically typecast as a number, you can add the `number` modifier to your `v-model` managed inputs:
+Si vous voulez que l'entrée utilisateur soit automatiquement typée en tant que nombre, vous pouvez ajouter le modificateur `number` à vos input gérés par `v-model`
 
 ``` html
 <input v-model.number="age" type="number">
 ```
 
-This is often useful, because even with `type="number"`, the value of HTML input elements always returns a string.
+C'est souvent utile, parce que même avec `type="number"`, la valeur des éléments input HTML retourne toujours une chaîne de caractères.
 
 ### `.trim`
 
 If you want user input to be trimmed automatically, you can add the `trim` modifier to your `v-model` managed inputs:
+c'est vous voulez que les entrées utilisateurs soit "trimmed" automatiquement, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model`
 
 ```html
 <input v-model.trim="msg">
 ```
 
-## `v-model` with Components
+## `v-model` avec les composants
 
-> If you're not yet familiar with Vue's components, just skip this for now.
+> Si vous n'est pas encore familier avec les composants de Vue, sautez ce passage pour le moment
 
-HTML's built-in input types won't always meet your needs. Fortunately, Vue components allow you to build reusable inputs with completely customized behavior. These inputs even work with `v-model`! To learn more, read about [custom inputs](components.html#Form-Input-Components-using-Custom-Events) in the Components guide.
+Les types de champ standards HTML ne couvriront pas toujours vos besoins. Heureusement, les composants de Vue vous permettent de construire des inputs avec un comportement complètement customisé. Ces inputs fonctionnent même avec `v-model` ! Pour en apprendre plus, lisez [inputs personnalisés](components.html#Form-Input-Components-using-Custom-Events) dans le guide des composants.
 
 
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -316,7 +316,7 @@ vm.toggle === vm.b
 ```
 
 ``` js
-// Lorsque c'est choisi :
+// lorsque c'est choisi :
 vm.pick === vm.a
 ```
 
@@ -330,7 +330,7 @@ vm.pick === vm.a
 ```
 
 ``` js
-// Lorsque c'est sélectionné :
+// lorsque c'est sélectionné :
 typeof vm.selected // -> 'object'
 vm.selected.number // -> 123
 ```

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -358,7 +358,7 @@ C'est souvent utile, parce que même avec `type="number"`, la valeur des éléme
 
 ### `.trim`
 
-c'est vous voulez que les saisies utilisateurs soit automatiquement nettoyées des espaces superflus, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model` :
+Si vous voulez que les saisies utilisateurs soit automatiquement nettoyées des espaces superflus, vous pouvez ajouter le modificateur `trim` à vos champs gérés par `v-model` :
 
 ```html
 <input v-model.trim="msg">

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -6,9 +6,9 @@ order: 10
 
 ## Usage basique
 
-Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les champs de formulaire et les ((textarea|zones de textes multilignes)). Elle choisira automatiquement la bonne manière de mettre à jour l'élément selon le type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ((plus quelques traitements spéciaux pour les cas particuliers)).
+Vous pouvez utilisez la directive `v-model` pour créer une liaison de donnée bidirectionnelle sur les ((champs de formulaire)). Elle choisira automatiquement la bonne manière de mettre à jour l'élément selon le type de champ. Bien qu'un peu magique, `v-model` est essentiellement un sucre syntaxique pour mettre à jour les données lors des évènements utilisateurs sur les champs, ((plus quelques traitements spéciaux pour les cas particuliers)).
 
-<p class="tip">`v-model` ne prend pas en compte la valeur initial fourni par un champ ou une zone de texte. Il traitera toujours les données de l'instance de vue comme la source de vérité.</p>
+<p class="tip">`v-model` ne prend pas en compte la valeur initiale fournie par un champ. Elle traitera toujours les données de l'instance de vue comme la source de vérité.</p>
 
 <p class="tip" id="vmodel-ime-tip">Pour les languages qui requièrent une [méthode de saisie (IME)](https://fr.wikipedia.org/wiki/M%C3%A9thode_d%27entr%C3%A9e) (chinois, japonais, coréen etc ...), vous remarquerez que `v-model` ne sera pas mis à jour durant ((l'exécution de la méthode de saisie.))</p>
 
@@ -62,8 +62,7 @@ new Vue({
 
 
 {% raw %}
-<p class="tip">Interpolation on textareas (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) won't work. Use <code>v-model</code> instead.</p>
-<p class="tip">Les interpolations sur les textareas (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionneront pas. Utilisez <code>v-model</code> à la place.</p>
+<p class="tip">Les interpolations sur les textarea (<code>&lt;textarea&gt;{{text}}&lt;/textarea&gt;</code>) ne fonctionneront pas. Utilisez <code>v-model</code> à la place.</p>
 {% endraw %}
 
 ### Checkbox
@@ -196,7 +195,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Select à choix multiple (lié à Array):
+Select à choix multiples (lié à Array):
 
 ``` html
 <select v-model="selected" multiple>
@@ -274,11 +273,10 @@ new Vue({
 </script>
 {% endraw %}
 
-## Value Bindings
-## Liaisons de value
+## Liaisons de valeurs
 
-For radio, checkbox and select options, the `v-model` binding values are usually static strings (or booleans for checkbox):
 Pour les options de bouton radio, checkbox et select, les valeurs de liaison de `v-model` sont habituellement des chaînes de caractères statiques (ou des booléens pour checkbox):
+
 
 ``` html
 <!-- `picked` est une chaîne de caractères "a" quand le bouton radio est sélectionné -->
@@ -320,7 +318,7 @@ vm.toggle === vm.b
 ```
 
 ``` js
-// when checked:
+// quand choisi :
 vm.pick === vm.a
 ```
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -279,13 +279,13 @@ Pour les options de bouton radio, checkbox et select, les valeurs de liaison de 
 
 
 ``` html
-<!-- `picked` est une chaîne de caractères "a" quand le bouton radio est sélectionné -->
+<!-- `picked` sera une chaîne de caractères "a" quand le bouton radio sera sélectionné -->
 <input type="radio" v-model="picked" value="a">
 
 <!-- `toggle` est soit true soit false -->
 <input type="checkbox" v-model="toggle">
 
-<!-- `selected` est une chaîne de caractères "abc" quand l'option est sélectionnée -->
+<!-- `selected` sera une chaîne de caractères "abc" quand l'option sera sélectionnée -->
 <select v-model="selected">
   <option value="abc">ABC</option>
 </select>

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -348,7 +348,7 @@ Par défaut, `v-model` synchronise le champ avec les données après chaque év�
 
 ### `.number`
 
-Si vous voulez que la saisie utilisateur soit automatiquement convertie en tant que nombre, vous pouvez ajouter le modificateur `number` à vos champs gérés par `v-model` :
+Si vous voulez que la saisie utilisateur soit automatiquement convertie en nombre, vous pouvez ajouter le modificateur `number` à vos champs gérés par `v-model` :
 
 ``` html
 <input v-model.number="age" type="number">

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -30,25 +30,25 @@ You can also perform one-time interpolations that do not update on data change b
 
 ### Raw HTML
 
-The double mustaches interprets the data as plain text, not HTML. In order to output real HTML, you will need to use the `v-html` directive:
+La double moustaches interprète les données comme du texte brut, pas comme du HTML. Pour vraiment afficher du HTML, vous aurez besoin de la directive `v-html`
 
 ``` html
 <div v-html="rawHtml"></div>
 ```
 
-The contents are inserted as plain HTML - data bindings are ignored. Note that you cannot use `v-html` to compose template partials, because Vue is not a string-based templating engine. Instead, components are preferred as the fundamental unit for UI reuse and composition.
+Le contenu sont insérés en tant que HTML - les liaisons de données sont ignorées. Notez que vous ne pouvez pas utiliser `v-html` pour composer des templates partiels, parce que Vue n'est pas un moteur de template basé sur les chaînes de caractères. A la place, les composants sont à préférer en tant qu'unité fondamentale pour la réutilisabilité de l'IU et la composition.
 
-<p class="tip">Dynamically rendering arbitrary HTML on your website can be very dangerous because it can easily lead to [XSS vulnerabilities](https://en.wikipedia.org/wiki/Cross-site_scripting). Only use HTML interpolation on trusted content and **never** on user-provided content.</p>
+<p class="tip"> Générer dynamiquement le rendu d'HTML arbitraire sur votre site peut être très dangereux car cela peut mener facilement à une [vulnérabilité XSS](https://en.wikipedia.org/wiki/Cross-site_scripting). Utilisez l'interpolation HTML uniquement sur du contenu de confiance et **jamais** sur du contenu en provenance d'un utilisateur</p>
 
-### Attributes
+### Les attributs
 
-Mustaches cannot be used inside HTML attributes, instead use a [v-bind directive](../api/#v-bind):
+Les Moustaches ne peuvent pas être utilisées à l'intérieur des attributs HTML, à la place utilisez une [directive v-bind](../api/#v-bind):
 
 ``` html
 <div v-bind:id="dynamicId"></div>
 ```
 
-It also works for boolean attributes - the attribute will be removed if the condition evaluates to a falsy value:
+Cela fonctionne également pour les attributs booléens - l'attribut sera supprimé si la condition est évaluée à faux :
 
 ``` html
 <button v-bind:disabled="someDynamicCondition">Button</button>


### PR DESCRIPTION
Voici forms.md. J'ai beaucoup hésité sur la manière de traduire "input"; j'ai donc besoin de vous. Le sens pouvant être plus ou moins large selon le contexte. Puisqu'il fallait choisir une direction j'ai fait comme suit pour l'instant : 

"Form inputs" et "Form inputs and textarea" => "les champs de fomulaire" (sens le plus large comprenant tous les types de champs)
"input elements" => les éléments input (par opposition à checkbox, select, textarea)
"User inputs" => les entrées utilisateurs (ce que rentre l'utilisateur dans un champ, quel qu'il soit)
"value" => valeur (mais j'ai précisé "attribut value") pour la première utilisation.

