### PR TITLE
computed.md : modification suite à une remarque de nyl-auster

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -34,7 +34,7 @@ var vm = new Vue({
     message: 'Bonjour'
   },
   computed: {
-    // un accesseur calculé
+    // un accesseur (getter) calculé
     reversedMessage: function () {
       // `this` pointe sur l'instance vm
       return this.message.split('').reverse().join('')


### PR DESCRIPTION
Pour rappel :
> Détail mineur : je vois que la deuxieme occurrence du mot accesseur est suivi de "getter" entre parenthèses pour expliciter: mais pas la première (ligne 37 "un accesseur calculé")