### PR TITLE
Re-fix `index.ejs` footer (forgot to wrap text between <p> tags)

### DIFF
--- a/themes/vue/layout/index.ejs
+++ b/themes/vue/layout/index.ejs
@@ -57,8 +57,8 @@
   <a href="https://www.shuttleworthfoundation.org/fellows/flash-grants/" target="_blank">
     <img src="/images/shuttleworth.png" style="width:200px">
   </a>
-  Publié sous <a href="https://opensource.org/licenses/MIT" href="_blank">Licence MIT</a><br>
-  Copyright &copy; 2014-<%- new Date().getFullYear() %> Evan You
+  <p>Publié sous <a href="https://opensource.org/licenses/MIT" href="_blank">Licence MIT</a><br>
+  Copyright &copy; 2014-<%- new Date().getFullYear() %> Evan You</p>
 </div>
 
 <script>


### PR DESCRIPTION
Étant dans l'impossibilité de ré-ouvrir la pull request #56 à propos du fichier `index.ejs`, j'ouvre donc une nouvelle pull request.

En effet, j'ai oublié d'entourer le texte du footer par les tags `<p>`, ce qui entraînait un affichage non désiré (le texte était sur la droite de l'image shuttleworthfoundation, au lieu d'être en dessous d'elle).