### PR TITLE
Fix forms guide

### DIFF
--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -100,7 +100,6 @@ Checkboxes multiples, liées au même tableau (Array) :
   <br>
   <span>Noms cochés : {{ checkedNames }}</span>
 <div>
->>>>>>> upstream/master
 ```
 
 ``` js


### PR DESCRIPTION
Remove `>>>>>>> upstream/master` from form guide