### PR TITLE
Corrige le nom d'une propriété dans l'énoncé

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -1025,7 +1025,7 @@ Et le template pour le composant de liste :
 
 #### Destructuration
 
-La valeur de `scope-slot` est en fait une expression JavaScript valide qui apparait à la position d'un argument dans la déclaration d'une fonction. Cela signifie que sur les environnements supportés (dans les composants monofichiers ou dans les navigateurs modernes) vous pouvez aussi utiliser la destructuration ES2015 dans une expression :
+La valeur de `slot-scope` est en fait une expression JavaScript valide qui apparait à la position d'un argument dans la déclaration d'une fonction. Cela signifie que sur les environnements supportés (dans les composants monofichiers ou dans les navigateurs modernes) vous pouvez aussi utiliser la destructuration ES2015 dans une expression :
 
 ``` html
 <child>


### PR DESCRIPTION
Légère coquille dans l'énoncé. La propriété originale `slot-scope` a été écrite à l'envers ( -> `scope-slot` ⚠)