### PR TITLE
Fix typo in mixin merge strategies

### DIFF
--- a/src/v2/guide/mixins.md
+++ b/src/v2/guide/mixins.md
@@ -35,7 +35,7 @@ var component = new Component() // => "hello from mixin!"
 
 Quand un mixin et un composant définissent les mêmes options, elles seront fusionnées en utilisant la stratégie appropriée.
 
-Par exemple, les objets de données subissant une fusion (une propriété profonde) avec les données d'un composant vont prendre la priorité en cas de conflits.
+Par exemple, les données d'un mixin et les données d'un composant subissent une fusion (une propriété profonde) avec les données du composant qui prennent la priorité en cas de conflits.
 
 ``` js
 var mixin = {
@@ -57,7 +57,7 @@ new Vue({
   },
   created: function () {
     console.log(this.$data)
-    // => { message: "bonjour", foo: "abc", bar: "def" }
+    // => { message: "au revoir", foo: "abc", bar: "def" }
   }
 })
 ```


### PR DESCRIPTION
Une erreur s'est glissée dans les stratégies de fusion de donnée entres les mixins et les données d'une instance/composant
(Les données prioritaires sont celles de l'instance/composant et pas celle du mixin)