### PR TITLE
Change translation typo in French example

### DIFF
--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -187,7 +187,7 @@ import Foo from './Foo'
 
 const factory = (values = {}) => {
   return shallowMount(Foo, {
-    data: { ...values  }
+    data() { return { ...values  }}
   })
 }
 

--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -140,7 +140,7 @@ Ce que l'on doit tester :
 * si `error` est `true`, `<div class="error">` devrait être visible
 * si `error` est `false`, `<div class="error">` ne devrait pas être présent
 
-Et enfin la version naïve de nos tests
+Et enfin la version naïve de nos tests utilisant jest:
 
 ```js
 import { shallowMount } from '@vue/test-utils'

--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -196,7 +196,7 @@ describe("Foo", () => {
     const wrapper = factory();
 
     expect(wrapper.find(".message").text()).toEqual(
-      "Welcome to the Vue.js cookbook"
+      "Bienvenue sur le tutoriel VueJs"
     );
   });
 


### PR DESCRIPTION
Hi!

I was going through the doc, testing the examples and I have encountered some typo:

1. In [unit-testing-vue-components.html](https://fr.vuejs.org/v2/cookbook/unit-testing-vue-components.html) The template is written in french `Bienvenue sur le tutoriel VueJs` and the test was testing the english version of it `Welcome to the Vue.js cookbook`. So I updated the test to make it test the french version.
2. Still in [unit-testing-vue-components.html](https://fr.vuejs.org/v2/cookbook/unit-testing-vue-components.html) the last test with the factory is not working because data is not set as a function so I updated it `data() { return { ...values  }}`  to and it run well now.
3. Still in [unit-testing-vue-components.html](https://fr.vuejs.org/v2/cookbook/unit-testing-vue-components.html) I wanted to make explicit the use of the jest notation for the tests, because they won't work with chai for example.

Thanks