### PR TITLE
Description plus claire pour les fusion mixin/composant

### DIFF
--- a/src/v2/guide/mixins.md
+++ b/src/v2/guide/mixins.md
@@ -37,7 +37,7 @@ var component = new Component() // => "hello from mixin!"
 
 Quand un mixin et un composant définissent les mêmes options, elles seront fusionnées en utilisant la stratégie appropriée.
 
-Par exemple, les données d'un mixin subissant une fusion (une propriété profonde) avec les données d'un composant vont prendre la priorité en cas de conflits.
+Par exemple, les objets `data` subissent une fusion recursive, avec les données du composant qui sont prioritaires sur celles du mixin en cas de conflits.
 
 ``` js
 var mixin = {


### PR DESCRIPTION
L'ancienne tournure de phrase laisse penser que les données du mixin sont prioritaires sur celles du composant (le code exemple correspondant lui est correct)

 `Par exemple, les données d’un mixin subissant une fusion (une propriété profonde) avec les données d’un composant vont prendre la priorité en cas de conflits.`

La nouvelle tournure me parait plus claire :)
