### PR TITLE
docs: update Scrimba link according to original docs

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -36,7 +36,7 @@ ou :
 
 La page d'[installation](installation.html) vous offre d'autres manières d'installer Vue. Notez que nous **ne** recommandons **pas** aux débutants de commencer avec `vue-cli`, surtout si vous n'êtes pas encore familier avec les outils de *build* basés sur Node.js.
 
-Si vous préférez quelque chose de plus interactif, vous pouvez également consulter [cette série de tutoriels sur Scrimba](https://scrimba.com/playlist/pXKqta), ce qui vous donnera un mélange de démonstration visuelle et de jeu avec le code que vous pourrez mettre en pause à n'importe quel moment.
+Si vous préférez quelque chose de plus interactif, vous pouvez également consulter [cette série de tutoriels sur Scrimba](https://scrimba.com/g/gvuedocs), ce qui vous donnera un mélange de démonstration visuelle et de jeu avec le code que vous pourrez mettre en pause à n'importe quel moment.
 
 ## Rendu déclaratif
 


### PR DESCRIPTION
The link to the Scrimba tutorial has changed. Evan You merged in the updated link to the original Vue docs earlier today, so I created this PR so that the Russian translation can stay up to date.

Here's the original PR: vuejs/vuejs.org#2368