### PR TITLE
[cookbook/index] suppression de '(en)'

### DIFF
--- a/src/v2/cookbook/index.md
+++ b/src/v2/cookbook/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction (EN)
+title: Introduction
 type: cookbook
 order: 0
 ---


### PR DESCRIPTION
Etant donné que la traduction de la page est terminée, on peut retirer le '(en)'