### PR TITLE
fix: change term "Réusabilité" for "Réutilisabilité"

### DIFF
--- a/themes/vue/layout/partials/toc.ejs
+++ b/themes/vue/layout/partials/toc.ejs
@@ -12,7 +12,7 @@
         <li><h3>Transitions & animation</h3></li>
       <% } %>
       <% if (fileName === 'mixins') { %>
-        <li><h3>Réusabilité & composition</h3></li>
+        <li><h3>Réutilisabilité & composition</h3></li>
       <% } %>
       <% if (fileName === 'single-file-components') { %>
         <li><h3>Outils</h3></li>


### PR DESCRIPTION
Cette PR change le terme "Réusabilité" pour "Réutilisabilité", comme décidé dans https://github.com/vuejs-fr/vuejs.org/issues/162.

Je n'ai trouvé qu'une occurrence.

fix #162